### PR TITLE
Bump version of Bookbindery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
 gem 'therubyracer'
-gem 'bookbindery', "9.12.1"
+gem 'bookbindery', "10.1.15"
 gem 'font-awesome-sass', '4.7.0'


### PR DESCRIPTION
The previous version of Book Bindery failed to start with errors. Bumping to 10.1.15 has resolved the errors & it starts again.